### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackaddr"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["shellrow <shellrow@fortnium.com>"]
 description = "Self-describing, layered network address representation, with flexible protocol stacks."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ readme = "README.md"
 serde = { version = "1", features = ["derive"], optional = true }
 bytes = { version = "1", features = [] }
 base32 = { version = "0.5" }
-uuid = { version = "1.16", features = [] }
-netdev = { version = "0.34", default-features = false, features = [] }
+uuid = { version = "1.17", features = [] }
+netdev = { version = "0.35", default-features = false, features = [] }
 
 [dev-dependencies]
 serde_json = "1.0"
 rand = "0.9"
-uuid = { version = "1.16", features = ["v4", "fast-rng"]}
+uuid = { version = "1.17", features = ["v4", "fast-rng"]}
 
 [features]
 #default = ["serde"]

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Self-describing, layered address representation library, designed with flexibili
 Add `stackaddr` to your dependencies:  
 ```toml:Cargo.toml
 [dependencies]
-stackaddr = "0.5"
+stackaddr = "0.6"
 ```
 
 To enable serde support:
 ```
 [dependencies]
-stackaddr = { version = "0.5", features = ["serde"] }
+stackaddr = { version = "0.6", features = ["serde"] }
 ```
 
 ## Example

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -11,13 +11,12 @@ fn random_bytes32() -> Bytes {
 }
 
 fn main() {
-    let id = random_bytes32();
     let addr = StackAddr::empty()
         .with_protocol(Protocol::Mac(MacAddr::from_hex_format("aa:bb:cc:dd:ee:ff")))
         .with_protocol(Protocol::Ip4("192.168.10.10".parse().unwrap()))
         .with_protocol(Protocol::Udp(4433))
         .with_protocol(Protocol::Quic)
-        .with_identity(Identity::NodeId(id.clone()));
+        .with_identity(Identity::NodeId(random_bytes32()));
 
     println!("{}", addr);
 }

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -227,7 +227,7 @@ impl StackAddr {
                 }
                 Segment::Protocol(Protocol::Tls) => {
                     if let Some(TransportProtocol::Tcp(p)) = port {
-                        return Some(TransportProtocol::TlsOverTcp(p));
+                        return Some(TransportProtocol::TlsTcp(p));
                     }
                 }
                 Segment::Protocol(Protocol::Ws(p)) => return Some(TransportProtocol::Ws(*p)),

--- a/src/segment/protocol.rs
+++ b/src/segment/protocol.rs
@@ -101,7 +101,7 @@ pub enum TransportProtocol {
     /// UDP port
     Udp(u16),
     /// TLS (over TCP)
-    TlsOverTcp(u16),
+    TlsTcp(u16),
     /// QUIC (over UDP)
     Quic(u16),
     /// WebSocket with port
@@ -118,7 +118,7 @@ impl TransportProtocol {
         match self {
             TransportProtocol::Tcp(p)
             | TransportProtocol::Udp(p)
-            | TransportProtocol::TlsOverTcp(p)
+            | TransportProtocol::TlsTcp(p)
             | TransportProtocol::Quic(p)
             | TransportProtocol::Ws(p)
             | TransportProtocol::Wss(p)
@@ -129,7 +129,7 @@ impl TransportProtocol {
     pub fn is_secure(&self) -> bool {
         matches!(
             self,
-            TransportProtocol::TlsOverTcp(_)
+            TransportProtocol::TlsTcp(_)
                 | TransportProtocol::Quic(_)
                 | TransportProtocol::Wss(_)
                 | TransportProtocol::WebTransport(_)
@@ -143,7 +143,7 @@ impl fmt::Display for TransportProtocol {
         match self {
             Tcp(port) => write!(f, "tcp/{}", port),
             Udp(port) => write!(f, "udp/{}", port),
-            TlsOverTcp(port) => write!(f, "tls/tcp/{}", port),
+            TlsTcp(port) => write!(f, "tls/tcp/{}", port),
             Quic(port) => write!(f, "quic/{}", port),
             Ws(port) => write!(f, "ws/{}", port),
             Wss(port) => write!(f, "wss/{}", port),


### PR DESCRIPTION
- Rename TransportProtocol::TlsOverTcp to TransportProtocol::TlsTcp
- Update dependencies